### PR TITLE
Random anonymous three

### DIFF
--- a/android/src/main/java/com/shatteredpixel/shatteredpixeldungeon/android/AndroidLauncher.java
+++ b/android/src/main/java/com/shatteredpixel/shatteredpixeldungeon/android/AndroidLauncher.java
@@ -48,9 +48,9 @@ public class AndroidLauncher extends Activity {
 			finish();
 		} catch (Exception e) {
 			TextView text = new TextView(this);
-			text.setText("Shattered Pixel Dungeon cannot start because some of its code is missing!\n\n"
+			text.setText("Flashcard Pixel Dungeon cannot start because some of its code is missing!\n\n"
 					+ "This usually happens when the Google Play version of the game is installed from somewhere outside of Google Play.\n\n"
-					+ "If you're unsure of how to fix this, please email the developer (Evan@ShatteredPixel.com), and include this error message:\n\n"
+					+ "If you're unsure of how to fix this, here's an error message:\n\n"
 					+ e.getMessage());
 			text.setTextSize(16);
 			text.setTextColor(0xFFFFFFFF);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Anonymizable.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Anonymizable.java
@@ -1,0 +1,8 @@
+package com.shatteredpixel.shatteredpixeldungeon.items;
+
+public abstract class Anonymizable extends Item
+{
+    public abstract void anonymize();
+
+    public abstract boolean isKnown();
+}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -96,7 +96,7 @@ public class Item implements Bundlable {
 
 	public List<String> actions(Hero hero) {
 		List<String> actions = new ArrayList<>();
-		actions.add(AC_DROP);
+		if (isTemp) {actions.add(AC_DROP);}
 		actions.add(AC_THROW);
 		return actions;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -96,7 +96,7 @@ public class Item implements Bundlable {
 
 	public List<String> actions(Hero hero) {
 		List<String> actions = new ArrayList<>();
-		if (isTemp) {actions.add(AC_DROP);}
+		if (!isTemp) {actions.add(AC_DROP);}
 		actions.add(AC_THROW);
 		return actions;
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
@@ -34,6 +34,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Burning;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Ooze;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Splash;
+import com.shatteredpixel.shatteredpixeldungeon.items.Anonymizable;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.ItemStatusHandler;
@@ -82,7 +83,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class Potion extends Item {
+public class Potion extends Anonymizable{
 
 	public static final String AC_DRINK = "DRINK";
 
@@ -180,10 +181,12 @@ public class Potion extends Item {
 	// effects
 	protected boolean anonymous = false;
 
+	@Override
 	public void anonymize() {
 		if (!isKnown())
 			image = ItemSpriteSheet.POTION_HOLDER;
 		anonymous = true;
+		this.setAction();
 	}
 
 	@Override
@@ -207,9 +210,9 @@ public class Potion extends Item {
 	}
 
 	public void setAction() {
-		if (isKnown() && mustThrowPots.contains(this.getClass())) {
+		if ((isKnown() || this.isTemp) && mustThrowPots.contains(this.getClass())) {
 			defaultAction = AC_THROW;
-		} else if (isKnown() && canThrowPots.contains(this.getClass())) {
+		} else if ((isKnown() || this.isTemp) && canThrowPots.contains(this.getClass())) {
 			defaultAction = AC_CHOOSE;
 		} else {
 			defaultAction = AC_DRINK;
@@ -351,7 +354,7 @@ public class Potion extends Item {
 
 	@Override
 	public String name() {
-		return isKnown() ? super.name() : Messages.get(this, color);
+		return isKnown() || this.isTemp ? super.name() : Messages.get(this, color);
 	}
 
 	@Override
@@ -386,7 +389,7 @@ public class Potion extends Item {
 	}
 
 	protected int splashColor() {
-		return anonymous ? 0x00AAFF : ItemSprite.pick(image, 5, 9);
+		return anonymous || this.isTemp ? 0x00AAFF : ItemSprite.pick(image, 5, 9);
 	}
 
 	protected void splash(int cell) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/potions/Potion.java
@@ -186,6 +186,11 @@ public class Potion extends Anonymizable{
 		if (!isKnown())
 			image = ItemSpriteSheet.POTION_HOLDER;
 		anonymous = true;
+	}
+
+	@Override
+	public void setTemp(boolean value) {
+		super.setTemp(value);
 		this.setAction();
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/Scroll.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/Scroll.java
@@ -25,6 +25,7 @@ import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Blindness;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.MagicImmune;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
+import com.shatteredpixel.shatteredpixeldungeon.items.Anonymizable;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.ItemStatusHandler;
 import com.shatteredpixel.shatteredpixeldungeon.items.Recipe;
@@ -58,7 +59,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public abstract class Scroll extends Item {
+public abstract class Scroll extends Anonymizable {
 
 	public static final String AC_READ = "READ";
 
@@ -123,6 +124,7 @@ public abstract class Scroll extends Item {
 	// effects
 	protected boolean anonymous = false;
 
+	@Override
 	public void anonymize() {
 		if (!isKnown())
 			image = ItemSpriteSheet.SCROLL_HOLDER;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/FlashDeckScene.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/FlashDeckScene.java
@@ -24,6 +24,7 @@ package com.shatteredpixel.shatteredpixeldungeon.scenes;
 import java.io.File;
 
 import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 import com.shatteredpixel.shatteredpixeldungeon.Chrome;
 import com.shatteredpixel.shatteredpixeldungeon.SPDSettings;
@@ -200,6 +201,9 @@ public class FlashDeckScene extends PixelScene {
     protected void onClick() {
       if (deckName == null) {
         JFileChooser fc = new JFileChooser();
+        fc.setAcceptAllFileFilterUsed(false);
+				FileNameExtensionFilter filter = new FileNameExtensionFilter("JSON Files", "json");
+				fc.addChoosableFileFilter(filter);
 
         int returnVal = fc.showOpenDialog(null);
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/FlashDeckScene.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/FlashDeckScene.java
@@ -113,12 +113,12 @@ public class FlashDeckScene extends PixelScene {
 
     public FlashDeckButton() {
       this.deckName = null;
-      set();
+      setActive();
     }
 
     public FlashDeckButton(String deckName, boolean isActive) {
       this.deckName = deckName;
-      set(isActive);
+      setActive(isActive);
     }
 
     @Override
@@ -132,11 +132,11 @@ public class FlashDeckScene extends PixelScene {
       add(name);
     }
 
-    private void set() {
-      set(false);
+    private void setActive() {
+      setActive(false);
     }
 
-    private void set(boolean isActive) {
+    private void setActive(boolean isActive) {
       if (deckName == null) {
         name.text(Messages.get(FlashDeckScene.class, "new"));
       } else {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndMysticalCardAnswer.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndMysticalCardAnswer.java
@@ -2,9 +2,13 @@ package com.shatteredpixel.shatteredpixeldungeon.windows;
 
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
 import com.shatteredpixel.shatteredpixeldungeon.ui.RedButton;
+import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
 import com.shatteredpixel.shatteredpixeldungeon.flashcard.IFlashQuestion;
 
 public class WndMysticalCardAnswer extends WndMysticalCard {
+
+  protected static final float FAILURE_TIME = 1.0f;
+
   WndMysticalCardAnswer(IFlashQuestion question) {
     super(question);
   }
@@ -44,7 +48,8 @@ public class WndMysticalCardAnswer extends WndMysticalCard {
 
   private void onQuestionFail() {
     question.increaseWeight();
-    GameScene.show(new WndMysticalCardQuestion(null));
+    Dungeon.hero.spendAndNext(FAILURE_TIME);
+    //GameScene.show(new WndMysticalCardQuestion(null));
   }
 
   private void onQuestionSuccess() {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndSelectEffect.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/windows/WndSelectEffect.java
@@ -2,13 +2,17 @@
 package com.shatteredpixel.shatteredpixeldungeon.windows;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import com.shatteredpixel.shatteredpixeldungeon.Assets;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
+import com.shatteredpixel.shatteredpixeldungeon.items.Anonymizable;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.items.MysticalCard;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.*;
@@ -64,8 +68,9 @@ public class WndSelectEffect extends Window {
         super.onClick();
         hide();
         try {
-          Item selectedItem = curSelection.getDeclaredConstructor().newInstance();
+          Anonymizable selectedItem = (Anonymizable) curSelection.getDeclaredConstructor().newInstance();
           selectedItem.setTemp(true);
+          if (!selectedItem.isKnown()) {selectedItem.anonymize();}
           selectedItem.execute(Dungeon.hero);
         } catch (Exception e) {
           GLog.n(e.getMessage());
@@ -85,11 +90,11 @@ public class WndSelectEffect extends Window {
     int row = action.equals(AC_USE_AS_POTION) ? 0 : 16;
     int placed = 0;
 
-    Set<Class<? extends Potion>> knownPotions = Potion.getKnown();
-    Set<Class<? extends Scroll>> knownScrolls = Scroll.getKnown();
-    for (int i = 0; i < classList.size(); ++i) {
+    //Set<Class<? extends Potion>> knownPotions = Potion.getKnown();
+    //Set<Class<? extends Scroll>> knownScrolls = Scroll.getKnown();
+    Collections.shuffle(classList);
+    for (int i = 0; i < 3; ++i) {
       final Class<? extends Item> itemClass = classList.get(i);
-      if (knownPotions.contains(itemClass) || knownScrolls.contains(itemClass)) {
         IconButton btn = new IconButton() {
           @Override
           protected void onClick() {
@@ -114,7 +119,6 @@ public class WndSelectEffect extends Window {
           }
           top += BTN_SIZE;
         }
-      }
     }
 
     resize(WIDTH, 115);

--- a/desktop/src/com/shatteredpixel/shatteredpixeldungeon/desktop/DesktopLauncher.java
+++ b/desktop/src/com/shatteredpixel/shatteredpixeldungeon/desktop/DesktopLauncher.java
@@ -42,8 +42,8 @@ public class DesktopLauncher {
 				PrintWriter pw = new PrintWriter(sw);
 				throwable.printStackTrace(pw);
 				pw.flush();
-				JOptionPane.showMessageDialog(null, "Shattered Pixel Dungeon has crashed, sorry about that!\n\n"
-						+ "If you could, please email this error message to me and I'll get it fixed (Evan@ShatteredPixel.com):\n\n"
+				JOptionPane.showMessageDialog(null, "Flashcard Pixel Dungeon has crashed, sorry about that!\n\n"
+						+ "If it's interesting, here's an error message:\n\n"
 						+ sw.toString(), "Game Crash!", JOptionPane.ERROR_MESSAGE);
 				Gdx.app.exit();
 			}


### PR DESCRIPTION
This request implemented all of the features implemented in #1 along with giving unknown potions the "anonymous" logo but with a readable name, made thrown potions not reveal their color, and made the scroll give a random choice of either three scrolls or three potions. This no longer picks from only the "known" potions / scrolls!

![image](https://user-images.githubusercontent.com/55124176/69390213-b121ef00-0c8b-11ea-8637-a1bd9277dec1.png)

![image](https://user-images.githubusercontent.com/55124176/69390236-c8f97300-0c8b-11ea-85fa-472e651f8ea3.png)
